### PR TITLE
fix: show bug in eval_buf

### DIFF
--- a/qjs.c
+++ b/qjs.c
@@ -501,7 +501,7 @@ int main(int argc, char **argv)
         }
 
         if (expr) {
-            printf("showing bug in eval_buf");
+            printf("showing bug in eval_buf\n");
             const char* extra_script = "init.fs";
             size_t expr_len = strlen(expr);
             char* debug_buf = malloc(expr_len + 100);

--- a/qjs.c
+++ b/qjs.c
@@ -1,6 +1,6 @@
 /*
  * QuickJS stand alone interpreter
- * 
+ *
  * Copyright (c) 2017-2021 Fabrice Bellard
  * Copyright (c) 2017-2021 Charlie Gordon
  *
@@ -82,7 +82,7 @@ static int eval_file(JSContext *ctx, const char *filename, int module)
     uint8_t *buf;
     int ret, eval_flags;
     size_t buf_len;
-    
+
     buf = js_load_file(ctx, &buf_len, filename);
     if (!buf) {
         perror(filename);
@@ -314,7 +314,7 @@ int main(int argc, char **argv)
     int load_jscalc;
 #endif
     size_t stack_size = 0;
-    
+
 #ifdef CONFIG_BIGNUM
     /* load jscalc runtime if invoked as 'qjscalc' */
     {
@@ -326,7 +326,7 @@ int main(int argc, char **argv)
         load_jscalc = !strcmp(exename, "qjscalc");
     }
 #endif
-    
+
     /* cannot use getopt because we want to pass the command line to
        the script */
     optind = 1;
@@ -477,7 +477,7 @@ int main(int argc, char **argv)
         JS_SetHostPromiseRejectionTracker(rt, js_std_promise_rejection_tracker,
                                           NULL);
     }
-    
+
     if (!empty_run) {
 #ifdef CONFIG_BIGNUM
         if (load_jscalc) {
@@ -501,7 +501,15 @@ int main(int argc, char **argv)
         }
 
         if (expr) {
-            if (eval_buf(ctx, expr, strlen(expr), "<cmdline>", 0))
+            printf("showing bug in eval_buf");
+            const char* extra_script = "init.fs";
+            size_t expr_len = strlen(expr);
+            char* debug_buf = malloc(expr_len + 100);
+            // first part is expr, without trailing zero
+            memcpy(debug_buf, expr, expr_len);
+            // immediately followed by a invalid script
+            memcpy(debug_buf + expr_len, extra_script, strlen(extra_script));
+            if (eval_buf(ctx, debug_buf, expr_len, "<cmdline>", 0))
                 goto fail;
         } else
         if (optind >= argc) {
@@ -518,7 +526,7 @@ int main(int argc, char **argv)
         }
         js_std_loop(ctx);
     }
-    
+
     if (dump_memory) {
         JSMemoryUsage stats;
         JS_ComputeMemoryUsage(rt, &stats);


### PR DESCRIPTION
When the argument `buf` in eval_buf is not end with \0, it can read extra token beyond `buf_len`.
```
❯ ./qjs -e "console.log('hi');"
showing bug in eval_buf
hi
ReferenceError: 'init' is not defined
    at <eval> (<cmdline>)
```
