### PR TITLE
fix: uncaught exception in module

### DIFF
--- a/qjs.c
+++ b/qjs.c
@@ -74,7 +74,16 @@ static int eval_buf(JSContext *ctx, const void *buf, int buf_len,
         js_std_dump_error(ctx);
         ret = -1;
     } else {
-        ret = 0;
+        if ((eval_flags & JS_EVAL_TYPE_MASK) == JS_EVAL_TYPE_MODULE) {
+            int promise_state = JS_PromiseState(ctx, val);
+            if (promise_state == JS_PROMISE_REJECTED) {
+                ret = -1;
+            } else {
+                ret = 0;
+            }
+        } else {
+            return 0;
+        }
     }
     JS_FreeValue(ctx, val);
     return ret;


### PR DESCRIPTION
Now it returns promise instead of exception directly.
Test it with following scripts:
```
❯ cat 1.mjs
throw 100;

❯ ./qjs 1.mjs
100
```
